### PR TITLE
Add php 8.0 as valid php version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         }
     ],
     "require": {
-        "php": "^7.0",
+        "php": "^7.0|^8.0",
         "laravel/framework": ">=5.0"
     },
     "autoload": {


### PR DESCRIPTION
I've quickly tested the different functions and they seem to work without issue in php 8.0. So I added this version in the config file.

This also becomes compatible with Laravel 8.